### PR TITLE
Cursor pointer changing in few scenario into cursor:not allowed autom…

### DIFF
--- a/client/public/style.css
+++ b/client/public/style.css
@@ -80,3 +80,43 @@ body:not(.loading) > .loader {
 }
 
 /* </animation> */
+
+
+
+/*Issue 1383 fix css property*/
+/*https://github.com/camunda/camunda-modeler/issues/1383*/
+
+.djs-cursor-grabbing {
+	cursor: context-menu !important;
+}
+.djs-element.djs-shape:hover {
+   cursor: context-menu !important;
+}
+
+.djs-drag-active.connect-not-ok:hover {
+	cursor: not-allowed !important;
+}
+
+.djs-element:hover{
+	cursor: context-menu !important;
+}
+
+.djs-element:active{
+	cursor: context-menu !important;
+}
+
+.djs-element:focus{
+	cursor: context-menu !important;
+}
+
+svg:hover{
+	cursor: context-menu !important;
+}
+
+svg:active{
+	cursor: context-menu !important;
+}
+
+svg:focus{
+	cursor: context-menu !important;
+}


### PR DESCRIPTION
…atically

OS: [Windows 10]
Camunda Modeler Version: [3.*]
Cursor behavior changing while connecting tasks module using arrow option.

Scenario :
When 2 objects are close and trying to connected the flow using arrow icon available from object tool bar. After mouse release inside another object also, cursor icon not changed from not-allowed mode to default mode.End user felt that its not allowed to add text or do other activities. Its changing only after the arrow icon from object tool tip.
Sample video available here : https://github.com/camunda/camunda-modeler/issues/1383

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?_

Closes #